### PR TITLE
[docs] Add kanban workflow documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,3 +48,8 @@ inheritance-chess/
 - **src/**: Implementation of core chess engine components.
 - **build/**: Temporary directory containing compilation artifacts and build outputs (Not commited).
 - **doc/**: Generated HTML and reference documentation (Not commited).
+
+## Project Management
+
+This project is managed using an engineering-focused Kanban board.
+See [Kanban workflow](docs/kanban.md) for details on columns and flow.

--- a/docs/kanban.md
+++ b/docs/kanban.md
@@ -1,0 +1,123 @@
+# 📋 Engineering Kanban Board
+
+This project uses a **Kanban board focused on engineering flow**, designed to manage feature development, architectural work, refactoring, testing, and documentation for a C++ object-oriented chess engine.
+
+The goal of this board is **visibility and quality**, not process rigidity.
+
+---
+
+## 🎯 Purpose of the Kanban
+
+- Visualize the real engineering workflow
+- Encourage small, well-defined units of work
+- Make architectural decisions and refactoring explicit
+- Promote collaboration through code reviews
+- Allow flexibility depending on the nature of the task
+
+---
+
+## 🧱 Board Columns Overview
+
+### **Backlog**
+Holds all potential work items, including ideas, improvements, and long-term tasks.  
+Items in this column are **not ready to be worked on yet**.
+
+---
+
+### **Ready**
+Represents work that has been refined and can be started immediately.  
+A task in *Ready* has:
+- Clear scope and goal
+- Enough context to begin implementation
+- No known blockers
+
+---
+
+### **In Progress**
+Tasks actively being worked on.  
+This column represents **focused development time**, and work-in-progress is intentionally kept limited.
+
+---
+
+### **Code Review**
+Tasks awaiting peer review before being merged.  
+This stage emphasizes:
+- Knowledge sharing
+- Code quality
+- Architectural consistency
+
+---
+
+### **Refactor / Improvements**
+Used for tasks focused on:
+- Design improvements
+- Code cleanup
+- Technical debt reduction
+
+Refactoring is treated as **first-class engineering work**, not as a side effect of feature development.
+
+---
+
+### **Testing**
+Tasks that require explicit validation through automated tests.  
+This column separates *“code written”* from *“code verified”*.
+
+---
+
+### **Done**
+Tasks that are fully completed according to the project’s Definition of Done:
+- Code merged
+- Required tests passing
+- Minimal documentation updated when applicable
+
+---
+
+## 🔀 Workflow and Flow Flexibility
+
+This Kanban board **does not enforce a single mandatory path**.  
+Different types of work may follow different flows depending on their nature.
+
+### Common flow examples:
+
+- **Feature development**
+```
+Backlog → Ready → In Progress → Code Review → Testing → Done
+```
+
+- **Small refactor or cleanup**
+```
+Backlog → Ready → In Progress → Code Review → Done
+```
+
+- **Pure refactoring task**
+```
+Backlog → Ready → Refactor / Improvements → Code Review → Done
+```
+
+- **Documentation-only task**
+```
+Backlog → Ready → In Progress → Done
+```
+
+- **Test-driven work**
+```
+Backlog → Ready → In Progress → Testing → Code Review → Done
+```
+
+---
+
+## 🧠 Engineering Principles Behind the Board
+
+- Not all tasks require the same level of ceremony
+- Quality is achieved through **intentional workflow design**
+- Refactoring, testing, and reviews are visible and valued
+- The board reflects how engineers *actually* work
+
+---
+
+## 📌 Final Note
+
+This Kanban board is a **tool**, not a rulebook.  
+Columns represent **possible stages** in the engineering process, not mandatory checkpoints.
+
+> *We optimize for clarity, quality, and collaboration over rigid process adherence.*


### PR DESCRIPTION
# Inheritance Chess C++ Engine - Pull Request Template

### 🧩 Summary
This PR solves #6 

### 🛠 Type of Change
It changes readme to add kanban documentation

  
|Type|Description|
|:---|:---|
|Docs|_Add kanban readme file._|
 

### 📊 Testing & Results
No testing needed to documentation PR

### 💡 Implementation Details
No code added

### ✅ Checklist
- [x] Project can be build fine.
- [x] Code follows clang format.
- [x] No new compiler warnings.
- [x] Updated documentation.

_Calileus Chess Pull Request Template V 1.0_
